### PR TITLE
add seed check for mev payment accounts

### DIFF
--- a/payment-vault/programs/payment-vault/src/lib.rs
+++ b/payment-vault/programs/payment-vault/src/lib.rs
@@ -24,9 +24,17 @@ const MEV_ACCOUNT_SEED_8: &'static [u8] = b"MEV_ACCOUNT_8";
 pub mod payment_vault {
     use super::*;
 
-    pub fn initialize(ctx: Context<Initialize>, _args: InitArgs) -> ProgramResult {
+    pub fn initialize(ctx: Context<Initialize>, args: InitArgs) -> ProgramResult {
         let cfg = &mut ctx.accounts.config;
         cfg.tip_claimer = ctx.accounts.initial_tip_claimer.key();
+        cfg.mev_bump_1 = args.mev_bump_1;
+        cfg.mev_bump_2 = args.mev_bump_2;
+        cfg.mev_bump_3 = args.mev_bump_3;
+        cfg.mev_bump_4 = args.mev_bump_4;
+        cfg.mev_bump_5 = args.mev_bump_5;
+        cfg.mev_bump_6 = args.mev_bump_6;
+        cfg.mev_bump_7 = args.mev_bump_7;
+        cfg.mev_bump_8 = args.mev_bump_8;
 
         Ok(())
     }
@@ -175,21 +183,53 @@ pub struct ClaimTips<'info> {
         constraint = config.tip_claimer == tip_claimer.key(),
     )]
     pub config: Account<'info, Config>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_1],
+        bump = config.mev_bump_1
+    )]
     pub mev_payment_account_1: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_2],
+        bump = config.mev_bump_2
+    )]
     pub mev_payment_account_2: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_3],
+        bump = config.mev_bump_3
+    )]
     pub mev_payment_account_3: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_4],
+        bump = config.mev_bump_4
+    )]
     pub mev_payment_account_4: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_5],
+        bump = config.mev_bump_5
+    )]
     pub mev_payment_account_5: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_6],
+        bump = config.mev_bump_6
+    )]
     pub mev_payment_account_6: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_7],
+        bump = config.mev_bump_7
+    )]
     pub mev_payment_account_7: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_8],
+        bump = config.mev_bump_8
+    )]
     pub mev_payment_account_8: Account<'info, MevPaymentAccount>,
     #[account(mut)]
     pub tip_claimer: AccountInfo<'info>,
@@ -223,21 +263,53 @@ pub struct SetTipClaimer<'info> {
     #[account(mut)]
     pub old_tip_claimer: AccountInfo<'info>,
     pub new_tip_claimer: AccountInfo<'info>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_1],
+        bump = config.mev_bump_1
+    )]
     pub mev_payment_account_1: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_2],
+        bump = config.mev_bump_2
+    )]
     pub mev_payment_account_2: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_3],
+        bump = config.mev_bump_3
+    )]
     pub mev_payment_account_3: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_4],
+        bump = config.mev_bump_4
+    )]
     pub mev_payment_account_4: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_5],
+        bump = config.mev_bump_5
+    )]
     pub mev_payment_account_5: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_6],
+        bump = config.mev_bump_6
+    )]
     pub mev_payment_account_6: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_7],
+        bump = config.mev_bump_7
+    )]
     pub mev_payment_account_7: Account<'info, MevPaymentAccount>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MEV_ACCOUNT_SEED_8],
+        bump = config.mev_bump_8
+    )]
     pub mev_payment_account_8: Account<'info, MevPaymentAccount>,
     #[account(mut)]
     pub signer: Signer<'info>,
@@ -267,6 +339,15 @@ impl<'info> SetTipClaimer<'info> {
 pub struct Config {
     /// The account claiming tips from the mev_payment accounts.
     tip_claimer: Pubkey,
+    /// Bumps used to derive MEV account PDAs.
+    mev_bump_1: u8,
+    mev_bump_2: u8,
+    mev_bump_3: u8,
+    mev_bump_4: u8,
+    mev_bump_5: u8,
+    mev_bump_6: u8,
+    mev_bump_7: u8,
+    mev_bump_8: u8,
 }
 
 /// Account that searchers will need to tip for their bundles to be accepted.

--- a/payment-vault/tests/payment-vault.js
+++ b/payment-vault/tests/payment-vault.js
@@ -2,7 +2,7 @@ const anchor = require( '@project-serum/anchor' )
 const assert = require( 'assert' )
 const { SystemProgram, Transaction } = anchor.web3
 
-const CONFIG_ACCOUNT_LEN = 8 + 32
+const CONFIG_ACCOUNT_LEN = 8 + 40
 const MEV_PAYMENT_ACCOUNT_LEN = 8
 
 const configAccountSeed = 'CONFIG_ACCOUNT'
@@ -40,8 +40,8 @@ describe( 'tests payment_vault', () => {
         )
     }
     const provider = anchor.Provider.local(
-      undefined,
-      { commitment: 'confirmed', preflightCommitment: 'confirmed' },
+        undefined,
+        { commitment: 'confirmed', preflightCommitment: 'confirmed' },
     )
     anchor.setProvider( provider )
     const paymentVaultProg = anchor.workspace.PaymentVault
@@ -147,21 +147,21 @@ describe( 'tests payment_vault', () => {
                 mevBump8,
             },
             {
-              accounts: {
-                  config: configAccount,
-                  initialTipClaimer: initializerKeys.publicKey,
-                  payer: initializerKeys.publicKey,
-                  systemProgram: SystemProgram.programId,
-                  mevPaymentAccount1,
-                  mevPaymentAccount2,
-                  mevPaymentAccount3,
-                  mevPaymentAccount4,
-                  mevPaymentAccount5,
-                  mevPaymentAccount6,
-                  mevPaymentAccount7,
-                  mevPaymentAccount8,
-              },
-              signers: [initializerKeys],
+                accounts: {
+                    config: configAccount,
+                    initialTipClaimer: initializerKeys.publicKey,
+                    payer: initializerKeys.publicKey,
+                    systemProgram: SystemProgram.programId,
+                    mevPaymentAccount1,
+                    mevPaymentAccount2,
+                    mevPaymentAccount3,
+                    mevPaymentAccount4,
+                    mevPaymentAccount5,
+                    mevPaymentAccount6,
+                    mevPaymentAccount7,
+                    mevPaymentAccount8,
+                },
+                signers: [initializerKeys],
             },
         )
         const configState = await paymentVaultProg.account.config.fetch( configAccount )
@@ -173,21 +173,21 @@ describe( 'tests payment_vault', () => {
         const newTipClaimer = anchor.web3.Keypair.generate()
         await paymentVaultProg.rpc.setTipClaimer(
             {
-              accounts: {
-                  oldTipClaimer,
-                  newTipClaimer: newTipClaimer.publicKey,
-                  config: configAccount,
-                  signer: initializerKeys.publicKey,
-                  mevPaymentAccount1,
-                  mevPaymentAccount2,
-                  mevPaymentAccount3,
-                  mevPaymentAccount4,
-                  mevPaymentAccount5,
-                  mevPaymentAccount6,
-                  mevPaymentAccount7,
-                  mevPaymentAccount8,
-              },
-              signers: [initializerKeys],
+                accounts: {
+                    oldTipClaimer,
+                    newTipClaimer: newTipClaimer.publicKey,
+                    config: configAccount,
+                    signer: initializerKeys.publicKey,
+                    mevPaymentAccount1,
+                    mevPaymentAccount2,
+                    mevPaymentAccount3,
+                    mevPaymentAccount4,
+                    mevPaymentAccount5,
+                    mevPaymentAccount6,
+                    mevPaymentAccount7,
+                    mevPaymentAccount8,
+                },
+                signers: [initializerKeys],
             },
         )
         await assertRentExemptAccounts()
@@ -196,28 +196,28 @@ describe( 'tests payment_vault', () => {
     })
     it( '#claim_tips `constraint = tip_claimer.key() == config.tip_claimer`', async () => {
         try {
-          const wrongTipClaimer = anchor.web3.Keypair.generate().publicKey
-          await paymentVaultProg.rpc.claimTips(
-              {
-                  accounts: {
-                      claimer: initializerKeys.publicKey,
-                      config: configAccount,
-                      tipClaimer: wrongTipClaimer,
-                      mevPaymentAccount1,
-                      mevPaymentAccount2,
-                      mevPaymentAccount3,
-                      mevPaymentAccount4,
-                      mevPaymentAccount5,
-                      mevPaymentAccount6,
-                      mevPaymentAccount7,
-                      mevPaymentAccount8,
-                  },
-                  signers: [initializerKeys],
-              },
-          )
-          assert( false )
+            const wrongTipClaimer = anchor.web3.Keypair.generate().publicKey
+            await paymentVaultProg.rpc.claimTips(
+                {
+                    accounts: {
+                        claimer: initializerKeys.publicKey,
+                        config: configAccount,
+                        tipClaimer: wrongTipClaimer,
+                        mevPaymentAccount1,
+                        mevPaymentAccount2,
+                        mevPaymentAccount3,
+                        mevPaymentAccount4,
+                        mevPaymentAccount5,
+                        mevPaymentAccount6,
+                        mevPaymentAccount7,
+                        mevPaymentAccount8,
+                    },
+                    signers: [initializerKeys],
+                },
+            )
+            assert( false )
         } catch ( e ) {
-          assert.equal( e.msg, 'A raw constraint was violated' )
+            assert.equal( e.msg, 'A raw constraint was violated' )
         }
     })
     it( '#claim_tips moves funds to correct account', async () => {


### PR DESCRIPTION
Fixes a bug where a new leader calls `set_tip_claimer` with 8 of the same mev_payment_accounts. The program transfers all lamports from ONE account to previous leader thinking it transferred from all 8. This adds a seed check on each account to make sure they are in fact the `mev_payment_account_n` they claim to be!