### PR TITLE
[JIT-240] Build on-chain programs in a reproducible manner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,9 +13,23 @@ env:
 jobs:
   build-and-test:
     name: Build and test programs
-    runs-on: projectserum/build:v0.25.0
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup/
+      - uses: ./.github/actions/setup-solana/
+      - uses: actions/cache@v2
+        name: Cache Cargo registry + index
+        id: cache-anchor
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./target/
+          key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+      - run: cargo install --git https://github.com/project-serum/anchor --tag v0.25.0 anchor-cli --locked --force
       - run: cd tip-payment && yarn
       - run: yarn global add mocha@^9.0.3 ts-mocha@^10.0.0
       - name: Create reproducible build


### PR DESCRIPTION
Notes:
- Subsequent ticket will upload reproducible build to apr.dev (https://linear.app/jito/issue/JIT-240/build-on-chain-programs-in-a-reproducible-mannerH)
- Build caching can be added later (extra 7 mins to run build)