### PR TITLE
[JIT-241] Upload on-chain programs to anchor registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,13 +14,10 @@ jobs:
     name: Build and test programs
     runs-on: ubuntu-20.04
     container: projectserum/build:v0.25.0
+    env:
+      HOME: /root
     steps:
       - uses: actions/checkout@v2
-      - run: ls /
-      - run: anchor
-      - run: solana
-#      - uses: ./.github/actions/setup/
-#      - uses: ./.github/actions/setup-solana/
       - uses: actions/cache@v2
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -32,15 +29,21 @@ jobs:
             ~/.cargo/git/db/
             ./target/
           key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
-#      - run: cargo install --git https://github.com/project-serum/anchor --tag v0.25.0 anchor-cli --locked --force
-      - run: cd tip-payment && yarn
-      - run: yarn global add mocha@^9.0.3 ts-mocha@^10.0.0
-      - name: Create reproducible build
+      - name: Install yarn dependencies
         working-directory: ./tip-payment
-        run: anchor build --verifiable
-      - name: test
+        run: yarn
+      - name: Run Anchor test
         working-directory: ./tip-payment
         run: anchor test
+      - name: Anchor Login
+        working-directory: ./tip-payment
+        run: anchor login ${{ secrets.ANCHOR_PUBLISH_TOKEN }}
+      - name: Create & Deploy verifiable tip-payment build
+        working-directory: ./tip-payment
+        run: anchor publish tip_payment
+      - name: Create & Deploy verifiable tip-distribution build
+        working-directory: ./tip-payment
+        run: anchor publish tip_distribution
       - uses: reinismu/clippy-check@master
         with:
           working-directory: ./tip-payment/programs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,10 +24,8 @@ jobs:
       - name: Setup upterm session
         uses: lhotari/action-upterm@v1
         with:
-        ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-        limit-access-to-actor: true
-        ## limits ssh access and adds the ssh public keys of the listed GitHub users
-        limit-access-to-users: esemeniuc
+          limit-access-to-actor: true
+          limit-access-to-users: esemeniuc
       - uses: actions/cache@v2
         name: Cache Cargo registry + index
         id: cache-anchor

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       HOME: /root
     steps:
 #      - uses: actions/checkout@v2
-      - run: file /root/.config/solana/id.json
+      - run: stat /root/.config/solana/id.json
       - uses: actions/cache@v2
         name: Cache Cargo registry + index
         id: cache-anchor

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,10 @@ jobs:
   build-and-test:
     name: Build and test programs
     runs-on: ubuntu-20.04
-    container: projectserum/build:v0.25.0
+    container:
+      image: projectserum/build:v0.25.0
+      volumes:
+        - ~/.config/solana/id.json:~/.config/solana/id.json
     env:
       HOME: /root
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       HOME: /root
     steps:
-      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v2
       - run: file /root/.config/solana/id.json
       - uses: actions/cache@v2
         name: Cache Cargo registry + index

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: ls /
       - run: solana
+      - run: anchor
 #      - uses: ./.github/actions/setup/
 #      - uses: ./.github/actions/setup-solana/
       - uses: actions/cache@v2
@@ -31,7 +32,7 @@ jobs:
             ~/.cargo/git/db/
             ./target/
           key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo install --git https://github.com/project-serum/anchor --tag v0.25.0 anchor-cli --locked --force
+#      - run: cargo install --git https://github.com/project-serum/anchor --tag v0.25.0 anchor-cli --locked --force
       - run: cd tip-payment && yarn
       - run: yarn global add mocha@^9.0.3 ts-mocha@^10.0.0
       - name: Create reproducible build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,13 +13,15 @@ jobs:
   build-and-test:
     name: Build and test programs
     runs-on: ubuntu-20.04
-    container:
-      image: projectserum/build:v0.25.0
-      volumes:
-        - $HOME/.config/solana/id.json:/root/.config/solana/id.json
+#    container:
+#      image: projectserum/build:v0.25.0
+#      volumes:
+#        - /home/runner/.config/solana/id.json:/root/.config/solana/id.json
     env:
       HOME: /root
     steps:
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         name: Cache Cargo registry + index

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,11 +18,16 @@ jobs:
 #      volumes:
 #        - /home/runner/.config/solana/id.json:/root/.config/solana/id.json
     env:
-      HOME: /root
+#      HOME: /root
     steps:
+      - uses: actions/checkout@v2
       - name: Setup upterm session
         uses: lhotari/action-upterm@v1
-      - uses: actions/checkout@v2
+        with:
+        ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+        limit-access-to-actor: true
+        ## limits ssh access and adds the ssh public keys of the listed GitHub users
+        limit-access-to-users: esemeniuc
       - uses: actions/cache@v2
         name: Cache Cargo registry + index
         id: cache-anchor

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: busybox:latest
       volumes:
-        - /home/runner/.config/solana/id.json:/root/.config/solana/id.json
+        - /home/runner/.config/solana:/root/.config/solana
     env:
       HOME: /root
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: projectserum/build:v0.25.0
       volumes:
-        - ~/.config/solana/id.json:~/.config/solana/id.json
+        - $HOME/.config/solana/id.json:/root/.config/solana/id.json
     env:
       HOME: /root
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,15 +35,6 @@ jobs:
       - name: Run Anchor test
         working-directory: ./tip-payment
         run: anchor test
-      - name: Anchor Login
-        working-directory: ./tip-payment
-        run: anchor login ${{ secrets.ANCHOR_PUBLISH_TOKEN }}
-      - name: Create & Deploy verifiable tip-payment build
-        working-directory: ./tip-payment
-        run: yes 'yes' | anchor publish tip_payment
-      - name: Create & Deploy verifiable tip-distribution build
-        working-directory: ./tip-payment
-        run: yes 'yes' | anchor publish tip_distribution
       - uses: reinismu/clippy-check@master
         with:
           working-directory: ./tip-payment/programs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       HOME: /root
     steps:
 #      - uses: actions/checkout@v2
-      - run: stat /root/.config/solana/id.json
+      - run: ls -lR /root/.config/solana/
       - uses: actions/cache@v2
         name: Cache Cargo registry + index
         id: cache-anchor

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,16 +13,11 @@ jobs:
   build-and-test:
     name: Build and test programs
     runs-on: ubuntu-20.04
-    container:
-      image: busybox:latest
-      volumes:
-        - /home/runner/.config/solana:/root/.config/solana
-    env:
-      HOME: /root
+
     steps:
-#      - uses: actions/checkout@v2
-      - run: ls -lR /root/.config/solana/
-      - run: cat /root/.config/solana/id.json | cut -c -3
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup/
+      - uses: ./.github/actions/setup-solana/
       - uses: actions/cache@v2
         name: Cache Cargo registry + index
         id: cache-anchor
@@ -34,6 +29,7 @@ jobs:
             ~/.cargo/git/db/
             ./target/
           key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+      - run: cargo install --git https://github.com/project-serum/anchor --tag v0.25.0 anchor-cli --locked --force
       - name: Install yarn dependencies
         working-directory: ./tip-payment
         run: yarn

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ls /
-      - run: solana
       - run: anchor
+      - run: solana
 #      - uses: ./.github/actions/setup/
 #      - uses: ./.github/actions/setup-solana/
       - uses: actions/cache@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
 #      image: projectserum/build:v0.25.0
 #      volumes:
 #        - /home/runner/.config/solana/id.json:/root/.config/solana/id.json
-    env:
+#    env:
 #      HOME: /root
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup upterm session
         uses: lhotari/action-upterm@v1
-        with:
-          limit-access-to-actor: true
-          limit-access-to-users: esemeniuc
+#        with:
+#          limit-access-to-actor: true
+#          limit-access-to-users: esemeniuc
       - uses: actions/cache@v2
         name: Cache Cargo registry + index
         id: cache-anchor

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,12 +13,12 @@ jobs:
   build-and-test:
     name: Build and test programs
     runs-on: ubuntu-20.04
-#    container:
-#      image: projectserum/build:v0.25.0
-#      volumes:
-#        - /home/runner/.config/solana/id.json:/root/.config/solana/id.json
-#    env:
-#      HOME: /root
+    container:
+      image: projectserum/build:v0.25.0
+      volumes:
+        - /home/runner/.config/solana/id.json:/root/.config/solana/id.json
+    env:
+      HOME: /root
     steps:
       - uses: actions/checkout@v2
       - name: Setup upterm session

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,18 +14,14 @@ jobs:
     name: Build and test programs
     runs-on: ubuntu-20.04
     container:
-      image: projectserum/build:v0.25.0
+      image: busybox:latest
       volumes:
         - /home/runner/.config/solana/id.json:/root/.config/solana/id.json
     env:
       HOME: /root
     steps:
       - uses: actions/checkout@v2
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-#        with:
-#          limit-access-to-actor: true
-#          limit-access-to-users: esemeniuc
+      - run: file /root/.config/solana/id.json
       - uses: actions/cache@v2
         name: Cache Cargo registry + index
         id: cache-anchor

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,10 +40,10 @@ jobs:
         run: anchor login ${{ secrets.ANCHOR_PUBLISH_TOKEN }}
       - name: Create & Deploy verifiable tip-payment build
         working-directory: ./tip-payment
-        run: anchor publish tip_payment
+        run: yes 'yes' | anchor publish tip_payment
       - name: Create & Deploy verifiable tip-distribution build
         working-directory: ./tip-payment
-        run: anchor publish tip_distribution
+        run: yes 'yes' | anchor publish tip_distribution
       - uses: reinismu/clippy-check@master
         with:
           working-directory: ./tip-payment/programs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
     steps:
 #      - uses: actions/checkout@v2
       - run: ls -lR /root/.config/solana/
+      - run: cat /root/.config/solana/id.json | cut -c -3
       - uses: actions/cache@v2
         name: Cache Cargo registry + index
         id: cache-anchor

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,7 @@ jobs:
   build-and-test:
     name: Build and test programs
     runs-on: ubuntu-20.04
+    container: projectserum/build:v0.25.0
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - gh-actions
   pull_request:
     branches:
       - master
@@ -17,8 +16,10 @@ jobs:
     container: projectserum/build:v0.25.0
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/setup/
-      - uses: ./.github/actions/setup-solana/
+      - run: ls /
+      - run: solana
+#      - uses: ./.github/actions/setup/
+#      - uses: ./.github/actions/setup-solana/
       - uses: actions/cache@v2
         name: Cache Cargo registry + index
         id: cache-anchor

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,34 @@
+name: Publish
+on:
+  push:
+    branches:
+      - master
+env:
+  SOLANA_CLI_VERSION: 1.10.39
+  NODE_VERSION: 17.0.1
+jobs:
+  publish-to-apr:
+    name: Publish to apr.dev
+    runs-on: ubuntu-20.04
+    container: projectserum/build:v0.25.0
+    env:
+      HOME: /root
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install yarn dependencies
+        working-directory: ./tip-payment
+        run: yarn
+      - name: Run Anchor test
+        working-directory: ./tip-payment
+        run: anchor test
+      - name: Anchor Login
+        working-directory: ./tip-payment
+        run: anchor login ${{ secrets.ANCHOR_PUBLISH_TOKEN }}
+      - name: Point to Mainnet (required for publishing)
+        run: sed -i 's/^cluster = ".*/cluster = "mainnet"/' Anchor.toml
+      - name: Publish verifiable tip-payment source code
+        working-directory: ./tip-payment
+        run: yes 'yes' | anchor publish tip_payment --skip-build
+      - name: Publish verifiable tip-distribution source code
+        working-directory: ./tip-payment
+        run: yes 'yes' | anchor publish tip_distribution --skip-build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,11 +8,23 @@ jobs:
   publish-to-apr:
     name: Publish to apr.dev
     runs-on: ubuntu-20.04
-    container: projectserum/build:v0.25.0
-    env:
-      HOME: /root
+
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup/
+      - uses: ./.github/actions/setup-solana/
+      - uses: actions/cache@v2
+        name: Cache Cargo registry + index
+        id: cache-anchor
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./target/
+          key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+      - run: cargo install --git https://github.com/project-serum/anchor --tag v0.25.0 anchor-cli --locked --force
       - name: Install yarn dependencies
         working-directory: ./tip-payment
         run: yarn

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,9 +3,7 @@ on:
   push:
     branches:
       - master
-env:
-  SOLANA_CLI_VERSION: 1.10.39
-  NODE_VERSION: 17.0.1
+
 jobs:
   publish-to-apr:
     name: Publish to apr.dev
@@ -26,9 +24,9 @@ jobs:
         run: anchor login ${{ secrets.ANCHOR_PUBLISH_TOKEN }}
       - name: Point to Mainnet (required for publishing)
         run: sed -i 's/^cluster = ".*/cluster = "mainnet"/' Anchor.toml
-      - name: Publish verifiable tip-payment source code
+      - name: Publish tip-payment source code
         working-directory: ./tip-payment
         run: yes 'yes' | anchor publish tip_payment --skip-build
-      - name: Publish verifiable tip-distribution source code
+      - name: Publish tip-distribution source code
         working-directory: ./tip-payment
         run: yes 'yes' | anchor publish tip_distribution --skip-build

--- a/tip-payment/Anchor.toml
+++ b/tip-payment/Anchor.toml
@@ -2,6 +2,10 @@
 cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
+[programs.mainnet]
+tip_distribution = "4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7"
+tip_payment = "T1pyyaTNZsKv2WcRAB8oVnk93mLJw2XzjtVYqCsaHqt"
+
 # 7heq is the deployer here
 [programs.testnet]
 tip_distribution = "7QnFbRZajkym8mUh9rXuM5nKrPAPRfEU6W31izSWJDVh"


### PR DESCRIPTION
Changes:
 - ~Switch to anchor docker image (saves about 12 mins of setup)~ -> running into issues with solana keypairs, scrapped for now
 - Add deployed program address from mainnet
 - Clean up yarn install

Notes:
- **Requires** `ANCHOR_PUBLISH_TOKEN` secret to be set
- Tested secrets potentially leaking, secrets are not passed into the CI/CD environment if the PR is opened by an outsider. Only upon PR merge by a collaborator will the secrets be available