### PR TITLE
Fix autosnapshot when the last slot in an epoch doesn't contain a block

### DIFF
--- a/tip-payment/scripts/autosnapshot.sh
+++ b/tip-payment/scripts/autosnapshot.sh
@@ -362,6 +362,7 @@ main() {
 
   post_slack_message "$SLACK_APP_TOKEN" "$SLACK_CHANNEL" "claiming mev tips epoch: $last_epoch slot: $previous_epoch_final_slot"
   claim_tips "$merkle_tree_filepath" "$RPC_URL" "$TIP_DISTRIBUTION_PROGRAM_ID" "$KEYPAIR"
+  post_slack_message "$SLACK_APP_TOKEN" "$SLACK_CHANNEL" "successfully claimed mev tips epoch: $last_epoch slot: $previous_epoch_final_slot"
 
   touch "$SNAPSHOT_DIR/$last_epoch.done"
 }


### PR DESCRIPTION
- autosnapshot errors out if the last slot in the epoch doesn't contain a block from this PR: https://github.com/solana-labs/solana/pull/27153

Fix:
- starting at the last slot in the epoch, loop backwards until there's a block that returns a result and take a snapshot there.