### PR TITLE
Fix autosnapshot pruning when nothing to prune

### DIFF
--- a/tip-payment/scripts/autosnapshot.sh
+++ b/tip-payment/scripts/autosnapshot.sh
@@ -197,7 +197,7 @@ get_filepath_in_gcloud() {
 
   echo "$file_uploaded"
 }
-SNAPSHOT_DIR=.
+
 prune_old_snapshots() {
   NUM_SNAPSHOTS_TO_KEEP=3
   local to_delete_stake

--- a/tip-payment/scripts/autosnapshot.sh
+++ b/tip-payment/scripts/autosnapshot.sh
@@ -209,10 +209,10 @@ prune_old_snapshots() {
   to_delete_merkle=$(find "$SNAPSHOT_DIR" -type f -name 'merkle-tree-[0-9]*.json' | sort | head -n -$NUM_SNAPSHOTS_TO_KEEP)
   to_delete_snapshot=$(find "$SNAPSHOT_DIR" -type f -name 'snapshot-[0-9]*-[[:alnum:]]*.tar.zst' | sort | head -n "-$NUM_SNAPSHOTS_TO_KEEP")
 
-  echo "pruning $(echo "$to_delete_snapshot" | wc -l) snapshots in $SNAPSHOT_DIR"
-  rm -f $to_delete_stake
-  rm -f $to_delete_merkle
-  rm -f $to_delete_snapshot
+  echo "pruning $(echo "$to_delete_snapshot" | wc -w) snapshots in $SNAPSHOT_DIR"
+  rm -f -v $to_delete_stake
+  rm -f -v $to_delete_merkle
+  rm -f -v $to_delete_snapshot
 }
 
 upload_file_to_gcloud() {

--- a/tip-payment/scripts/autosnapshot.sh
+++ b/tip-payment/scripts/autosnapshot.sh
@@ -197,7 +197,7 @@ get_filepath_in_gcloud() {
 
   echo "$file_uploaded"
 }
-
+SNAPSHOT_DIR=.
 prune_old_snapshots() {
   NUM_SNAPSHOTS_TO_KEEP=3
   local to_delete_stake
@@ -210,9 +210,9 @@ prune_old_snapshots() {
   to_delete_snapshot=$(find "$SNAPSHOT_DIR" -type f -name 'snapshot-[0-9]*-[[:alnum:]]*.tar.zst' | sort | head -n "-$NUM_SNAPSHOTS_TO_KEEP")
 
   echo "pruning $(echo "$to_delete_snapshot" | wc -l) snapshots in $SNAPSHOT_DIR"
-  [[ -n $to_delete_stake ]] && rm -v $to_delete_stake
-  [[ -n $to_delete_merkle ]] && rm -v $to_delete_merkle
-  [[ -n $to_delete_snapshot ]] && rm -v $to_delete_snapshot
+  rm -f $to_delete_stake
+  rm -f $to_delete_merkle
+  rm -f $to_delete_snapshot
 }
 
 upload_file_to_gcloud() {


### PR DESCRIPTION
Notes:
- `set -e` ends the script when a bash function has non-zero return code for the last line.

Example (`Finished main` will not print):
```
#!/bin/bash
set -eux

SNAPSHOT_DIR=.
prune_old_snapshots() {
  NUM_SNAPSHOTS_TO_KEEP=3
  local to_delete_stake
  local to_delete_merkle
  local to_delete_snapshot

  # sorts by timestamp in filename
  to_delete_stake=$(find "$SNAPSHOT_DIR" -type f -name 'stake-meta-[0-9]*.json' | sort | head -n -$NUM_SNAPSHOTS_TO_KEEP)
  to_delete_merkle=$(find "$SNAPSHOT_DIR" -type f -name 'merkle-tree-[0-9]*.json' | sort | head -n -$NUM_SNAPSHOTS_TO_KEEP)
  to_delete_snapshot=$(find "$SNAPSHOT_DIR" -type f -name 'snapshot-[0-9]*-[[:alnum:]]*.tar.zst' | sort | head -n "-$NUM_SNAPSHOTS_TO_KEEP")

  echo "pruning $(echo "$to_delete_snapshot" | wc -l) snapshots in $SNAPSHOT_DIR"
  [[ -n $to_delete_stake ]] && echo $to_delete_stake
  [[ -n $to_delete_merkle ]] && echo $to_delete_merkle
  [[ -n $to_delete_snapshot ]] && echo $to_delete_snapshot
#  echo "Finished fn"
}
prune_old_snapshots

echo "Finished main"
```

Test script on files generated by:

```bash
echo "368.done
369.done
370.done
371.done
372.done
373.done
374.done
375.done
376.done
377.done
378.done
379.done
autosnapshot_logs.txt
genesis.bin
merkle-tree-163295999.json
merkle-tree-163727999.json
merkle-tree-164159999.json
snapshot-163295999-C2PcTpD1ad62idBxyhyjN66i9vQXYy9cdPfzAjfgQC2s.tar.zst
snapshot-163727999-Dy9cTypEmwHFimoQxtSQV3TgoPghXtY9U2D5irjdVs7R.tar.zst
snapshot-164159999-gDX7eAb8ZpzzZRqA1WA5AAgoY6Ct6QdcBtSyx8tFXmu.tar.zst
stake-meta-163295999.json
stake-meta-163727999.json
stake-meta-164159999.json" | xargs touch
```