### PR TITLE
Fix package name of tip-payment and distribution

### DIFF
--- a/mev-programs/programs/tip-distribution/Cargo.toml
+++ b/mev-programs/programs/tip-distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "tip-distribution"
-version = "0.1.0"
+name = "jito-tip-distribution"
+version = "0.1.2"
 description = "Tip distribution program, responsible for distributing funds to entitled parties."
 edition = "2021"
 license = "Apache-2.0"

--- a/mev-programs/programs/tip-payment/Cargo.toml
+++ b/mev-programs/programs/tip-payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "tip-payment"
-version = "0.1.0"
+name = "jito-tip-payment"
+version = "0.1.2"
 description = "Tip Payment Program"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Somehow these got out of sync with the name on crates.io, they were uploaded with this name here: https://github.com/jito-foundation/jito-programs/commit/86fac29c487b70aea40d193ab621859ba2ef9dbe
https://crates.io/crates/jito-tip-payment/versions
https://crates.io/crates/jito-tip-distribution/versions