### PR TITLE
Feat: add tip router merkle root upload support

### DIFF
--- a/mev-programs/programs/sdk/src/instruction.rs
+++ b/mev-programs/programs/sdk/src/instruction.rs
@@ -249,6 +249,7 @@ pub struct ClaimArgs {
 pub struct ClaimAccounts {
     pub config: Pubkey,
     pub tip_distribution_account: Pubkey,
+    pub merkle_root_upload_authority: Pubkey,
     pub claim_status: Pubkey,
     pub claimant: Pubkey,
     pub payer: Pubkey,
@@ -264,6 +265,7 @@ pub fn claim_ix(program_id: Pubkey, args: ClaimArgs, accounts: ClaimAccounts) ->
     let ClaimAccounts {
         config,
         tip_distribution_account,
+        merkle_root_upload_authority,
         claim_status,
         claimant,
         payer,
@@ -281,6 +283,7 @@ pub fn claim_ix(program_id: Pubkey, args: ClaimArgs, accounts: ClaimAccounts) ->
         accounts: jito_tip_distribution::accounts::Claim {
             config,
             tip_distribution_account,
+            merkle_root_upload_authority,
             claimant,
             claim_status,
             payer,

--- a/mev-programs/programs/tip-distribution/idl/jito_tip_distribution.json
+++ b/mev-programs/programs/tip-distribution/idl/jito_tip_distribution.json
@@ -214,6 +214,48 @@
       ]
     },
     {
+      "name": "initialize_merkle_root_upload_config",
+      "discriminator": [
+        232,
+        87,
+        72,
+        14,
+        89,
+        40,
+        40,
+        27
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "merkle_root_upload_config",
+          "writable": true
+        },
+        {
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
       "name": "initialize_tip_distribution_account",
       "docs": [
         "Initialize a new [TipDistributionAccount] associated with the given validator vote key",
@@ -271,6 +313,29 @@
       ]
     },
     {
+      "name": "migrate_tda_merkle_root_upload_authority",
+      "discriminator": [
+        13,
+        226,
+        163,
+        144,
+        56,
+        202,
+        214,
+        23
+      ],
+      "accounts": [
+        {
+          "name": "tip_distribution_account",
+          "writable": true
+        },
+        {
+          "name": "merkle_root_upload_config"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "update_config",
       "docs": [
         "Update config fields. Only the [Config] authority can invoke this."
@@ -304,6 +369,43 @@
               "name": "Config"
             }
           }
+        }
+      ]
+    },
+    {
+      "name": "update_merkle_root_upload_config",
+      "discriminator": [
+        128,
+        227,
+        159,
+        139,
+        176,
+        128,
+        118,
+        2
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "merkle_root_upload_config",
+          "writable": true
+        },
+        {
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "authority",
+          "type": "pubkey"
         }
       ]
     },
@@ -385,6 +487,19 @@
         250,
         204,
         130
+      ]
+    },
+    {
+      "name": "MerkleRootUploadConfig",
+      "discriminator": [
+        213,
+        125,
+        30,
+        192,
+        25,
+        121,
+        87,
+        33
       ]
     },
     {
@@ -582,6 +697,11 @@
       "code": 6014,
       "name": "Unauthorized",
       "msg": "Unauthorized signer."
+    },
+    {
+      "code": 6015,
+      "name": "InvalidTdaForMigration",
+      "msg": "TDA not valid for migration."
     }
   ],
   "types": [
@@ -823,6 +943,31 @@
           {
             "name": "new_authority",
             "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MerkleRootUploadConfig",
+      "docs": [
+        "Singleton account that allows overriding TDA's merkle upload authority"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "overide_authority",
+            "docs": [
+              "The authority that overrides the TipDistributionAccount merkle_root_upload_authority"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "The bump used to genearte this account"
+            ],
+            "type": "u8"
           }
         ]
       }

--- a/mev-programs/programs/tip-distribution/idl/jito_tip_distribution.json
+++ b/mev-programs/programs/tip-distribution/idl/jito_tip_distribution.json
@@ -231,12 +231,11 @@
       ],
       "accounts": [
         {
-          "name": "payer",
-          "writable": true,
-          "signer": true
+          "name": "config",
+          "writable": true
         },
         {
-          "name": "config",
+          "name": "merkle_root_upload_config",
           "writable": true
         },
         {
@@ -244,8 +243,9 @@
           "signer": true
         },
         {
-          "name": "merkle_root_upload_config",
-          "writable": true
+          "name": "payer",
+          "writable": true,
+          "signer": true
         },
         {
           "name": "system_program"
@@ -254,6 +254,10 @@
       "args": [
         {
           "name": "authority",
+          "type": "pubkey"
+        },
+        {
+          "name": "original_authority",
           "type": "pubkey"
         }
       ]
@@ -392,12 +396,12 @@
           "name": "config"
         },
         {
-          "name": "authority",
-          "signer": true
-        },
-        {
           "name": "merkle_root_upload_config",
           "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
         },
         {
           "name": "system_program"
@@ -406,6 +410,10 @@
       "args": [
         {
           "name": "authority",
+          "type": "pubkey"
+        },
+        {
+          "name": "original_authority",
           "type": "pubkey"
         }
       ]
@@ -957,16 +965,24 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "overide_authority",
+            "name": "override_authority",
             "docs": [
               "The authority that overrides the TipDistributionAccount merkle_root_upload_authority"
             ],
             "type": "pubkey"
           },
           {
+            "name": "original_upload_authority",
+            "docs": [
+              "The original merkle root upload authority that can be changed to the new overrided",
+              "authority. E.g. Jito Labs authority GZctHpWXmsZC1YHACTGGcHhYxjdRqQvTpYkb9LMvxDib"
+            ],
+            "type": "pubkey"
+          },
+          {
             "name": "bump",
             "docs": [
-              "The bump used to genearte this account"
+              "The bump used to generate this account"
             ],
             "type": "u8"
           }

--- a/mev-programs/programs/tip-distribution/idl/jito_tip_distribution.json
+++ b/mev-programs/programs/tip-distribution/idl/jito_tip_distribution.json
@@ -241,7 +241,6 @@
         },
         {
           "name": "authority",
-          "writable": true,
           "signer": true
         },
         {
@@ -390,12 +389,10 @@
       ],
       "accounts": [
         {
-          "name": "config",
-          "writable": true
+          "name": "config"
         },
         {
           "name": "authority",
-          "writable": true,
           "signer": true
         },
         {

--- a/mev-programs/programs/tip-distribution/idl/jito_tip_distribution.json
+++ b/mev-programs/programs/tip-distribution/idl/jito_tip_distribution.json
@@ -31,6 +31,10 @@
           "writable": true
         },
         {
+          "name": "merkle_root_upload_authority",
+          "signer": true
+        },
+        {
           "name": "claim_status",
           "docs": [
             "Status of the claim. Used to prevent the same party from claiming multiple times."

--- a/mev-programs/programs/tip-distribution/src/lib.rs
+++ b/mev-programs/programs/tip-distribution/src/lib.rs
@@ -521,8 +521,14 @@ impl CloseTipDistributionAccount<'_> {
 pub struct Claim<'info> {
     pub config: Account<'info, Config>,
 
-    #[account(mut, rent_exempt = enforce)]
+    #[account(
+        mut,
+        has_one = merkle_root_upload_authority @ Unauthorized,
+        rent_exempt = enforce,
+    )]
     pub tip_distribution_account: Account<'info, TipDistributionAccount>,
+
+    pub merkle_root_upload_authority: Signer<'info>,
 
     /// Status of the claim. Used to prevent the same party from claiming multiple times.
     #[account(

--- a/mev-programs/programs/tip-distribution/src/lib.rs
+++ b/mev-programs/programs/tip-distribution/src/lib.rs
@@ -26,7 +26,7 @@ pub mod state;
 
 declare_id!("4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7");
 
-static JITO_UPLOAD_AUTHORITY: Pubkey = pubkey!("GZctHpWXmsZC1YHACTGGcHhYxjdRqQvTpYkb9LMvxDib");
+static JITO_LABS_UPLOAD_AUTHORITY: Pubkey = pubkey!("GZctHpWXmsZC1YHACTGGcHhYxjdRqQvTpYkb9LMvxDib");
 
 #[program]
 pub mod jito_tip_distribution {
@@ -297,7 +297,7 @@ pub mod jito_tip_distribution {
         // Set the bump and override authority
         let merkle_root_upload_config = &mut ctx.accounts.merkle_root_upload_config;
         merkle_root_upload_config.bump = ctx.bumps.merkle_root_upload_config;
-        merkle_root_upload_config.overide_authority = authority;
+        merkle_root_upload_config.override_authority = authority;
         Ok(())
     }
 
@@ -310,7 +310,7 @@ pub mod jito_tip_distribution {
 
         // Update override authority
         let merkle_root_upload_config = &mut ctx.accounts.merkle_root_upload_config;
-        merkle_root_upload_config.overide_authority = authority;
+        merkle_root_upload_config.override_authority = authority;
 
         Ok(())
     }
@@ -324,13 +324,13 @@ pub mod jito_tip_distribution {
             return Err(InvalidTdaForMigration.into());
         }
         // Validate the TDA key is Jito's key
-        if distribution_account.merkle_root_upload_authority != JITO_UPLOAD_AUTHORITY {
+        if distribution_account.merkle_root_upload_authority != JITO_LABS_UPLOAD_AUTHORITY {
             return Err(InvalidTdaForMigration.into());
         }
 
         // Change the TDA's root upload authority
         distribution_account.merkle_root_upload_authority =
-            ctx.accounts.merkle_root_upload_config.overide_authority;
+            ctx.accounts.merkle_root_upload_config.override_authority;
 
         Ok(())
     }

--- a/mev-programs/programs/tip-distribution/src/lib.rs
+++ b/mev-programs/programs/tip-distribution/src/lib.rs
@@ -597,13 +597,8 @@ impl UploadMerkleRoot<'_> {
 
 #[derive(Accounts)]
 pub struct InitializeMerkleRootUploadConfig<'info> {
-    #[account(mut)]
-    pub payer: Signer<'info>,
-
     #[account(mut, rent_exempt = enforce)]
     pub config: Account<'info, Config>,
-
-    pub authority: Signer<'info>,
 
     #[account(
         init,
@@ -616,6 +611,11 @@ pub struct InitializeMerkleRootUploadConfig<'info> {
         payer = payer
     )]
     pub merkle_root_upload_config: Account<'info, MerkleRootUploadConfig>,
+
+    pub authority: Signer<'info>,
+
+    #[account(mut)]
+    pub payer: Signer<'info>,
 
     pub system_program: Program<'info, System>,
 }
@@ -635,8 +635,6 @@ pub struct UpdateMerkleRootUploadConfig<'info> {
     #[account(rent_exempt = enforce)]
     pub config: Account<'info, Config>,
 
-    pub authority: Signer<'info>,
-
     #[account(
         mut,
         seeds = [MerkleRootUploadConfig::SEED],
@@ -644,6 +642,8 @@ pub struct UpdateMerkleRootUploadConfig<'info> {
         rent_exempt = enforce,
     )]
     pub merkle_root_upload_config: Account<'info, MerkleRootUploadConfig>,
+
+    pub authority: Signer<'info>,
 
     pub system_program: Program<'info, System>,
 }

--- a/mev-programs/programs/tip-distribution/src/lib.rs
+++ b/mev-programs/programs/tip-distribution/src/lib.rs
@@ -28,8 +28,6 @@ declare_id!("4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7");
 
 static JITO_UPLOAD_AUTHORITY: Pubkey = pubkey!("GZctHpWXmsZC1YHACTGGcHhYxjdRqQvTpYkb9LMvxDib");
 
-
-
 #[program]
 pub mod jito_tip_distribution {
     use jito_programs_vote_state::VoteState;
@@ -316,7 +314,7 @@ pub mod jito_tip_distribution {
     }
 
     pub fn migrate_tda_merkle_root_upload_authority(
-        ctx: Context<MigrateTdaMerkleRootUploadAuthority>
+        ctx: Context<MigrateTdaMerkleRootUploadAuthority>,
     ) -> Result<()> {
         let distribution_account = &mut ctx.accounts.tip_distribution_account;
         // Validate TDA has no MerkleRoot uploaded to it
@@ -329,7 +327,8 @@ pub mod jito_tip_distribution {
         }
 
         // Change the TDA's root upload authority
-        distribution_account.merkle_root_upload_authority = ctx.accounts.merkle_root_upload_config.overide_authority;
+        distribution_account.merkle_root_upload_authority =
+            ctx.accounts.merkle_root_upload_config.overide_authority;
 
         Ok(())
     }

--- a/mev-programs/programs/tip-distribution/src/state.rs
+++ b/mev-programs/programs/tip-distribution/src/state.rs
@@ -181,9 +181,9 @@ impl ClaimStatus {
 #[derive(Default)]
 pub struct MerkleRootUploadConfig {
     /// The authority that overrides the TipDistributionAccount merkle_root_upload_authority
-    pub overide_authority: Pubkey,
+    pub override_authority: Pubkey,
 
-    /// The bump used to genearte this account
+    /// The bump used to generate this account
     pub bump: u8,
 }
 

--- a/mev-programs/programs/tip-distribution/src/state.rs
+++ b/mev-programs/programs/tip-distribution/src/state.rs
@@ -183,6 +183,10 @@ pub struct MerkleRootUploadConfig {
     /// The authority that overrides the TipDistributionAccount merkle_root_upload_authority
     pub override_authority: Pubkey,
 
+    /// The original merkle root upload authority that can be changed to the new overrided 
+    /// authority. E.g. Jito Labs authority GZctHpWXmsZC1YHACTGGcHhYxjdRqQvTpYkb9LMvxDib
+    pub original_upload_authority: Pubkey,
+
     /// The bump used to generate this account
     pub bump: u8,
 }

--- a/mev-programs/programs/tip-distribution/src/state.rs
+++ b/mev-programs/programs/tip-distribution/src/state.rs
@@ -175,3 +175,20 @@ impl ClaimStatus {
 
     pub const SIZE: usize = HEADER_SIZE + size_of::<Self>();
 }
+
+/// Singleton account that allows overriding TDA's merkle upload authority
+#[account]
+#[derive(Default)]
+pub struct MerkleRootUploadConfig {
+    /// The authority that overrides the TipDistributionAccount merkle_root_upload_authority
+    pub overide_authority: Pubkey,
+
+    /// The bump used to genearte this account
+    pub bump: u8,
+}
+
+impl MerkleRootUploadConfig {
+    pub const SEED: &'static [u8] = b"ROOT_UPLOAD_CONFIG";
+
+    pub const SIZE: usize = HEADER_SIZE + size_of::<Self>();
+}

--- a/mev-programs/tests/tip-distribution.ts
+++ b/mev-programs/tests/tip-distribution.ts
@@ -5,7 +5,6 @@ import { JitoTipDistribution } from "../target/types/jito_tip_distribution";
 import { assert, expect } from "chai";
 import {
   PublicKey,
-  TransactionInstruction,
   VoteInit,
   VoteProgram,
 } from "@solana/web3.js";
@@ -925,7 +924,7 @@ describe("tests tip_distribution", () => {
     }
   });
 
-  it("#iniialize_merkle_root_upload_conifg happy path", async () => {
+  it("#initialize_merkle_root_upload_conifg happy path", async () => {
     await setup_initTipDistributionAccount();
 
     const [_merkleRootUploadConfigKey, merkleRootUploadConfigBump] =
@@ -935,9 +934,14 @@ describe("tests tip_distribution", () => {
       );
     const overrideAuthority = anchor.web3.Keypair.generate();
 
+    const originalAuthority = anchor.web3.Keypair.generate();
+
     // call the init instruction
     await tipDistribution.methods
-      .initializeMerkleRootUploadConfig(overrideAuthority.publicKey)
+      .initializeMerkleRootUploadConfig(
+        overrideAuthority.publicKey,
+        originalAuthority.publicKey,
+      )
       .accounts({
         payer: tipDistribution.provider.publicKey,
         config: configAccount,
@@ -956,8 +960,12 @@ describe("tests tip_distribution", () => {
     // Validate the MerkleRootUploadConfig authority is the Config authority
     assert.equal(merkleRootUploadConfig.bump, merkleRootUploadConfigBump);
     assert.equal(
-      merkleRootUploadConfig.overideAuthority.toString(),
+      merkleRootUploadConfig.overrideAuthority.toString(),
       overrideAuthority.publicKey.toString(),
+    );
+    assert.equal(
+      merkleRootUploadConfig.originalUploadAuthority.toString(),
+      originalAuthority.publicKey.toString(),
     );
   });
 
@@ -967,7 +975,10 @@ describe("tests tip_distribution", () => {
     const newOverrideAuthority = anchor.web3.Keypair.generate();
 
     await tipDistribution.methods
-      .updateMerkleRootUploadConfig(newOverrideAuthority.publicKey)
+      .updateMerkleRootUploadConfig(
+        newOverrideAuthority.publicKey,
+        JITO_MERKLE_UPLOAD_AUTHORITY,
+      )
       .accounts({
         config: configAccount,
         authority: authority.publicKey,
@@ -983,8 +994,12 @@ describe("tests tip_distribution", () => {
       );
     // Validate the MerkleRootUploadConfig authority is the new authority
     assert.equal(
-      updatedMerkleRootUploadConfig.overideAuthority.toString(),
+      updatedMerkleRootUploadConfig.overrideAuthority.toString(),
       newOverrideAuthority.publicKey.toString(),
+    );
+    assert.equal(
+      updatedMerkleRootUploadConfig.originalUploadAuthority.toString(),
+      JITO_MERKLE_UPLOAD_AUTHORITY.toString(),
     );
   });
 
@@ -1025,7 +1040,7 @@ describe("tests tip_distribution", () => {
     );
     assert.equal(
       tda.merkleRootUploadAuthority.toString(),
-      merkleRootUploadConfig.overideAuthority.toString(),
+      merkleRootUploadConfig.overrideAuthority.toString(),
     );
   });
 

--- a/mev-programs/tests/tip-distribution.ts
+++ b/mev-programs/tests/tip-distribution.ts
@@ -945,6 +945,39 @@ describe("tests tip_distribution", () => {
       overrideAuthority.publicKey.toString(),
     );
   });
+
+  it("#update_merkle_root_upload_conifg happy path", async () => {
+    await setup_initTipDistributionAccount();
+
+    const [merkleRootUploadConfigKey, merkleRootUploadConfigBump] =
+      anchor.web3.PublicKey.findProgramAddressSync(
+        [Buffer.from(ROOT_UPLOAD_CONFIG_SEED, "utf8")],
+        tipDistribution.programId,
+      );
+
+    const newOverrideAuthority = anchor.web3.Keypair.generate();
+
+    await tipDistribution.methods
+      .updateMerkleRootUploadConfig(newOverrideAuthority.publicKey)
+      .accounts({
+        config: configAccount,
+        authority: authority.publicKey,
+        merkleRootUploadConfig: merkleRootUploadConfigKey,
+        systemProgram: anchor.web3.SystemProgram.programId,
+      })
+      .signers([authority])
+      .rpc({ skipPreflight: true });
+
+    const updatedMerkleRootUploadConfig =
+      await tipDistribution.account.merkleRootUploadConfig.fetch(
+        merkleRootUploadConfigKey,
+      );
+    // Validate the MerkleRootUploadConfig authority is the new authority
+    assert.equal(
+      updatedMerkleRootUploadConfig.overideAuthority.toString(),
+      newOverrideAuthority.publicKey.toString(),
+    );
+  });
 });
 
 // utils


### PR DESCRIPTION
* Changes made ensure backwards compatibility for validators
* Instructions
    * InitializeMerkleRootUploadConfig - Initializes a singleton account for storing and override authority (that should be signer from TipRouter)
    * UpdateMerkleRootUploadConfig - Allows the Config.authority to update the override authority
    * MigrateTdaMerkleRootUploadAuthority - Allows permissionless change of any `TipDistributionAccount.merkle_root_upload_authority` to be the TipRouter's authority IF it's the current Jito authority (`GZctHpWXmsZC1YHACTGGcHhYxjdRqQvTpYkb9LMvxDib`)
