### PR TITLE
Fix Verified Build for Tip Payment and Tip Distribution

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,10 +46,7 @@ jobs:
       # Build IDLs
       - name: Build jito_tip_distribution
         working-directory: ./mev-programs
-        run: anchor build --idl idl --program-name jito_tip_distribution
-      - name: Build jito_tip_payment
-        working-directory: ./mev-programs
-        run: anchor build --idl idl --program-name jito_tip_payment
+        run: anchor build
 
       # Test
       - name: Run Anchor test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,12 +30,9 @@ jobs:
             ./mev-programs/target/
           key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install Rust toolchain 1.75.0
-        uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.75.0-x86_64-unknown-linux-gnu
-          profile: minimal
-          override: true
+          toolchain: 1.75.0
       
       - run: cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli --locked --force
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,16 @@ jobs:
             ~/.cargo/git/db/
             ./mev-programs/target/
           key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Rust toolchain 1.75.0
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.75.0-x86_64-unknown-linux-gnu
+          profile: minimal
+          override: true
+      
       - run: cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli --locked --force
+
       - name: Install yarn dependencies
         working-directory: ./mev-programs
         run: yarn
@@ -69,7 +78,7 @@ jobs:
 
       - run: docker pull --platform linux/amd64 solanafoundation/solana-verifiable-build:2.1.11
 
-      # - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install solana-verify from crates.io
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - run: docker pull --platform linux/amd64 solanafoundation/solana-verifiable-build:2.1.11
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      # - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install solana-verify from crates.io
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,10 @@ jobs:
       # Build IDLs
       - name: Build jito_tip_distribution
         working-directory: ./mev-programs
-        run: anchor build
+        run: anchor build --idl idl --program-name jito_tip_distribution
+      - name: Build jito_tip_payment
+        working-directory: ./mev-programs
+        run: anchor build --idl idl --program-name jito_tip_payment
 
       # Test
       - name: Run Anchor test
@@ -64,17 +67,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # --force because the cargo cache has it saved
-      - name: Install Solana Verify
-        run: |
-          cargo install solana-verify --force
-          solana-verify --version
+      - run: docker pull --platform linux/amd64 solanafoundation/solana-verifiable-build:2.1.11
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install solana-verify from crates.io
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: solana-verify
 
       - name: Verifiable Build
         working-directory: ./mev-programs
         run: |
-          solana-verify build --library-name jito_tip_distribution
-          solana-verify build --library-name jito_tip_payment
+          solana-verify build --library-name jito_tip_distribution --base-image solanafoundation/solana-verifiable-build:2.1.11
+          solana-verify build --library-name jito_tip_payment --base-image solanafoundation/solana-verifiable-build:2.1.11
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,5 +89,5 @@ jobs:
           path: |
             mev-programs/target/deploy/jito_tip_distribution.so
             mev-programs/target/deploy/jito_tip_payment.so
-            mev-programs/target/idl/jito_tip_distribution.json
-            mev-programs/target/idl/jito_tip_payment.json
+            mev-programs/programs/tip-distribution/idl/jito_tip_distribution.json
+            mev-programs/programs/tip-payment/idl/jito_tip_payment.json


### PR DESCRIPTION
Fixes #130 

- Fix installing `solana-verify`