### PR TITLE
feat: define jito-priority-fee-distribution crate

### DIFF
--- a/mev-programs/Cargo.toml
+++ b/mev-programs/Cargo.toml
@@ -21,6 +21,7 @@ anchor-lang = { version = "0.31.1" }
 bincode = "1.3.3"
 jito-programs-vote-state = { path = "programs/vote-state", version = "=0.1.6" }
 jito-tip-distribution = { path = "programs/tip-distribution", version = "=0.1.6", features = ["no-entrypoint", "no-idl"] }
+jito-priority-fee-distribution = { path = "programs/priority-fee-distribution", version = "=0.1.6", features = ["no-entrypoint", "no-idl"] }
 jito-tip-payment = { path = "programs/tip-payment", version = "=0.1.6" }
 proc-macro2 = "=1.0.95"
 serde = "1.0.138"

--- a/mev-programs/Cargo.toml
+++ b/mev-programs/Cargo.toml
@@ -19,9 +19,9 @@ edition = "2021"
 agave-feature-set = "2.2"
 anchor-lang = { version = "0.31.1" }
 bincode = "1.3.3"
+jito-priority-fee-distribution = { path = "programs/priority-fee-distribution", version = "=0.1.6", features = ["no-entrypoint", "no-idl"] }
 jito-programs-vote-state = { path = "programs/vote-state", version = "=0.1.6" }
 jito-tip-distribution = { path = "programs/tip-distribution", version = "=0.1.6", features = ["no-entrypoint", "no-idl"] }
-jito-priority-fee-distribution = { path = "programs/priority-fee-distribution", version = "=0.1.6", features = ["no-entrypoint", "no-idl"] }
 jito-tip-payment = { path = "programs/tip-payment", version = "=0.1.6" }
 proc-macro2 = "=1.0.95"
 serde = "1.0.138"


### PR DESCRIPTION
**Problem**
We would like to reference the priority fee distribution crate from an external repo but it does not yet exist.

**Solution**
- Define jito-priority-fee-distribution local crate in the top-level Cargo.toml